### PR TITLE
Typing fixes

### DIFF
--- a/disk_objectstore/container.py
+++ b/disk_objectstore/container.py
@@ -53,12 +53,11 @@ from .utils import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator
     from typing import (
         Any,
         Callable,
-        Iterator,
         Literal,
-        Sequence,
     )
 
 ObjQueryResults = namedtuple('ObjQueryResults', ['hashkey', 'offset', 'length', 'compressed', 'size'])
@@ -509,7 +508,7 @@ class Container:  # pylint: disable=too-many-public-methods
     @overload
     def _get_objects_stream_meta_generator(
         self,
-        hashkeys: Sequence[str],
+        hashkeys: Iterable[str],
         skip_if_missing: bool,
         with_streams: Literal[False],
     ) -> Iterator[tuple[str, ObjectMeta]]: ...
@@ -517,14 +516,14 @@ class Container:  # pylint: disable=too-many-public-methods
     @overload
     def _get_objects_stream_meta_generator(
         self,
-        hashkeys: Sequence[str],
+        hashkeys: Iterable[str],
         skip_if_missing: bool,
         with_streams: Literal[True],
     ) -> Iterator[tuple[str, StreamSeekBytesType | None, ObjectMeta]]: ...
 
     def _get_objects_stream_meta_generator(  # pylint: disable=too-many-branches,too-many-statements,too-many-locals
         self,
-        hashkeys: Sequence[str],
+        hashkeys: Iterable[str],
         skip_if_missing: bool,
         with_streams: bool,
     ) -> Iterator[(tuple[str, ObjectMeta] | tuple[str, StreamSeekBytesType | None, ObjectMeta])]:
@@ -539,7 +538,7 @@ class Container:  # pylint: disable=too-many-public-methods
         :note: do not use directly! Call always the proper public methods. This is only
             for internal use
 
-        :param hashkeys: a list of hash keys for which we want to get a stream reader
+        :param hashkeys: an iterable of hash keys for which we want to get a stream reader
         :param skip_if_missing: if True, just skip hash keys that are not in the container
             (i.e., neither packed nor loose). If False, return ``None`` instead of the
             stream.
@@ -804,7 +803,7 @@ class Container:  # pylint: disable=too-many-public-methods
 
     @contextmanager
     def get_objects_stream_and_meta(
-        self, hashkeys: Sequence[str], skip_if_missing: bool = True
+        self, hashkeys: Iterable[str], skip_if_missing: bool = True
     ) -> Iterator[Iterator[tuple[str, StreamSeekBytesType | None, ObjectMeta]]]:
         """A context manager returning a generator yielding triplets of (hashkey, open stream, metadata).
 
@@ -846,7 +845,7 @@ class Container:  # pylint: disable=too-many-public-methods
         return LazyLooseStream(container=self, hashkey=hashkey)
 
     def get_objects_meta(
-        self, hashkeys: Sequence[str], skip_if_missing: bool = True
+        self, hashkeys: Iterable[str], skip_if_missing: bool = True
     ) -> Iterator[tuple[str, ObjectMeta]]:
         """A generator yielding pairs of (hashkey, metadata).
 
@@ -2013,7 +2012,7 @@ class Container:  # pylint: disable=too-many-public-methods
 
     def import_objects(  # pylint: disable=too-many-locals,too-many-statements,too-many-branches,too-many-arguments
         self,
-        hashkeys: Sequence[str],
+        hashkeys: Iterable[str],
         source_container: Container,
         compress: bool = False,
         target_memory_bytes: int = 104857600,

--- a/disk_objectstore/container.py
+++ b/disk_objectstore/container.py
@@ -2568,9 +2568,9 @@ class Container:  # pylint: disable=too-many-public-methods
         # At least one object. Let's repack. We have checked before that the
         # REPACK_PACK_ID did not exist.
         if callback:
-            callback(  # type: ignore[call-arg]
-                action='init',
-                value={
+            callback(
+                'init',
+                {
                     'total': self.get_total_size()['total_size_packed'],
                     'description': f'Repack {pack_id}',
                 },
@@ -2671,14 +2671,14 @@ class Container:  # pylint: disable=too-many-public-methods
                     # I will assume that all objects of a single pack fit in memory
                     obj_dicts.append(obj_dict)
                     if callback:
-                        callback(action='update', value=obj_dict['size'])  # type: ignore[call-arg]
+                        callback('update', obj_dict['size'])
             # safe flush to disk seems to be a time consuming operation, but no easy way to include in the progress bar
             safe_flush_to_disk(
                 write_pack_handle,
                 self._get_pack_path_from_pack_id(self._REPACK_PACK_ID, allow_repack_pack=True),
             )
         if callback:
-            callback(action='close', value=None)  # type: ignore[call-arg]
+            callback('close', None)
         # We are done with data transfer.
         # At this stage we just have a new pack -1 (_REPACK_PACK_ID) but it is never referenced.
         # Let us store the information in the DB.

--- a/disk_objectstore/dataclasses.py
+++ b/disk_objectstore/dataclasses.py
@@ -7,7 +7,7 @@ from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, List, Optional, Union
 
 if TYPE_CHECKING:
-    from container import ObjectType
+    from .container import ObjectType
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
This PR contains to typing fixes that were uncovered by adding typing in aiida-core in aiidateam/aiida-core#7049

1. In aiida-core, we're passing a `set()` as hashkeys argument, but set is not a Sequence so mypy in aiida-core complains. `typing.Iterable` correctly captures the type what we accept here since we anyway convert it to `set` internally.

2. Remove usage of `mypy_extensions.Arg` which is deprecated and doesn't actually work as intended over at aiida-core repo. 