### PR TITLE
Remove pyupgrade and flynt pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,11 +24,6 @@ repos:
       # Check and update the uv lockfile
     - id: uv-lock
 
-  - repo: https://github.com/ikamensh/flynt/
-    rev: '1.0.1'
-    hooks:
-    - id: flynt
-
   - repo: https://github.com/executablebooks/mdformat
     rev: '0.7.17'
     hooks:
@@ -38,12 +33,6 @@ repos:
       - mdformat-gfm
       - mdformat-black
       files: (?x)^(README\.md|CHANGELOG\.md)$
-
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.14.0
-    hooks:
-    - id: pyupgrade
-      args: [--py37-plus]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.8.6

--- a/disk_objectstore/cli.py
+++ b/disk_objectstore/cli.py
@@ -6,7 +6,7 @@ import logging
 import os
 import sys
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
 import click
 
@@ -142,7 +142,7 @@ def validate(dostore: ContainerContext, verbose: bool):
 @main.command('add-files')
 @click.argument('files', nargs=-1, type=click.Path(exists=True))
 @pass_dostore
-def add_files(dostore: ContainerContext, files: List[str]):
+def add_files(dostore: ContainerContext, files: list[str]):
     """Add file(s) to the container"""
     with dostore.container as container:
         click.echo(f'Adding {len(files)} file(s) to container: {container.get_folder()}')

--- a/disk_objectstore/dataclasses.py
+++ b/disk_objectstore/dataclasses.py
@@ -4,7 +4,7 @@ a number of methods.
 """
 
 from dataclasses import asdict, dataclass
-from typing import TYPE_CHECKING, List, Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 if TYPE_CHECKING:
     from .container import ObjectType
@@ -113,10 +113,10 @@ class ValidationIssues:
         have some overlap
     """
 
-    invalid_hashes_loose: List[str]
-    invalid_hashes_packed: List[str]
-    invalid_sizes_packed: List[str]
-    overlapping_packed: List[str]
+    invalid_hashes_loose: list[str]
+    invalid_hashes_packed: list[str]
+    invalid_sizes_packed: list[str]
+    overlapping_packed: list[str]
 
     def __getitem__(self, item: str) -> Union[str, int, bool, None]:
         """Return members using dictionary access.

--- a/disk_objectstore/utils.py
+++ b/disk_objectstore/utils.py
@@ -13,6 +13,7 @@ import itertools
 import os
 import uuid
 import zlib
+from collections.abc import Iterable, Iterator, Sequence
 from contextlib import contextmanager
 from enum import Enum
 from pathlib import Path
@@ -21,10 +22,7 @@ from typing import (
     Any,
     BinaryIO,
     Callable,
-    Iterable,
-    Iterator,
     Literal,
-    Sequence,
     Union,
 )
 from zlib import error

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,7 @@ select = [
   'PLR',  # pylint-refactor
   'PLW',  # pylint-warning
   'RUF',  # ruff
+  'FLY',  # flynt (f-string formatting)
   'UP'    # pyupgrade
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,10 +95,6 @@ exclude = [
     'tests/',
 ]
 
-[tool.flynt]
-line-length = 120
-fail-on-change = true
-
 [tool.ruff]
 line-length = 120
 
@@ -134,7 +130,8 @@ select = [
   'PLE',  # pylint-error
   'PLR',  # pylint-refactor
   'PLW',  # pylint-warning
-  'RUF'  # ruff
+  'RUF',  # ruff
+  'UP'    # pyupgrade
 ]
 
 [tool.mypy]


### PR DESCRIPTION
Use the corresponding ruff rules instead.
(see also corresponding PR in aiida-core that removed flynt https://github.com/aiidateam/aiida-core/pull/7022)

All the code changes are autofixes from ruff.