### PR TITLE
Add close() and flush() methods to stream classes for full file-like compatibility

### DIFF
--- a/disk_objectstore/utils.py
+++ b/disk_objectstore/utils.py
@@ -548,6 +548,12 @@ class PackedObjectReader:
     def closed(self) -> bool:
         return self._fhandle.closed
 
+    def close(self) -> None:
+        """Close the reader. Does not close the underlying file handle since it is shared."""
+
+    def flush(self) -> None:
+        """Flush is a no-op for a read-only stream."""
+
     @staticmethod
     def seekable() -> bool:
         """Return whether object supports random access."""
@@ -682,6 +688,12 @@ class CallbackStreamWrapper:
     @property
     def closed(self) -> bool:
         return self._stream.closed
+
+    def close(self) -> None:
+        """Close the wrapper. Does not close the underlying stream."""
+
+    def flush(self) -> None:
+        """Flush is a no-op for a read-only stream."""
 
     def seekable(self) -> bool:
         """Return whether object supports random access."""
@@ -833,6 +845,12 @@ class ZlibLikeBaseStreamDecompresser(abc.ABC):
         return self._compressed_stream.closed and (
             self._lazy_uncompressed_stream is None or self._lazy_uncompressed_stream.closed
         )
+
+    def close(self) -> None:
+        """Close the decompresser. Does not close the underlying compressed stream."""
+
+    def flush(self) -> None:
+        """Flush is a no-op for a read-only stream."""
 
     def read(self, size: int = -1) -> bytes:
         """


### PR DESCRIPTION
These test on aiida-core are flaky 
```
FAILED tests/engine/processes/calcjobs/test_calc_job.py::TestCalcJob::test_get_hash - AttributeError: 'PackedObjectReader' object has no attribute 'close'
FAILED tests/engine/processes/calcjobs/test_calc_job.py::TestCalcJob::test_get_objects_attributes - AttributeError: 'PackedObjectReader' object has no attribute 'close'
FAILED tests/engine/processes/calcjobs/test_calc_job.py::TestCalcJob::test_compute_hash_version_independent - AttributeError: 'PackedObjectReader' object has no attribute 'close'
FAILED tests/engine/processes/calcjobs/test_calc_job.py::test_monitor_version - AttributeError: 'PackedObjectReader' object has no attribute 'close'
FAILED tests/engine/processes/calcjobs/test_calc_job.py::test_monitor_result_override_exit_code - AttributeError: 'PackedObjectReader' object has no attribute 'close'
FAILED tests/engine/processes/calcjobs/test_calc_job.py::test_monitor_result_action_disable_all - AttributeError: 'PackedObjectReader' object has no attribute 'close'
FAILED tests/engine/processes/calcjobs/test_calc_job.py::test_monitor_result_action_disable_self - AttributeError: 'PackedObjectReader' object has no attribute 'close'
FAILED tests/engine/processes/calcjobs/test_calc_job.py::test_restart_after_daemon_reset - AssertionError: The process excepted: AttributeError: 'PackedObjectReader' object has no attribute 'flush'
```

The flakiness comes down to whether objects are loose or packed in the disk-objectstore at the time the test reads from the repository. The point is disk-objectstore packs objects automatically when certain thresholds are reached.
If the packed object are returned they still should support close() and flush(), becausein aiida-core TextIOWrapper is used as a context manager, its __exit__ calls close(), which propagates to the underlying stream. 


The commit adda no-op close() and flush() methods to PackedObjectReader, CallbackStreamWrapper, and ZlibLikeBaseStreamDecompresser.

This was discovered in aiidateam/aiida-core#7206, where async changes results in different tests ordering or something resulting to this issue to pop out. 
The methods are intentionally no-ops because these readers don't own the underlying file handles they read from.
